### PR TITLE
Changing range of bunny version fo compatibility issues

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     hovercat (0.2.4)
-      bunny (= 2.5.1)
+      bunny (>= 2.5.1, <= 2.6.0)
       rails (>= 4.2.5.1, <= 5.0.0.1)
 
 GEM
@@ -46,7 +46,7 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     amq-protocol (2.0.1)
-    arel (7.1.2)
+    arel (7.1.4)
     builder (3.2.2)
     bunny (2.5.1)
       amq-protocol (>= 2.0.1)

--- a/hovercat.gemspec
+++ b/hovercat.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
   s.add_dependency 'rails', '>= 4.2.5.1', '<= 5.0.0.1'
-  s.add_dependency 'bunny', '2.5.1'
+  s.add_dependency 'bunny', '>= 2.5.1', '<= 2.6.0'
 
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'rspec-rails'


### PR DESCRIPTION
The version of bunny is generate a compatibility issue with others gens like sneakers.io. I setup this to a valid range.