### PR TITLE
Config refactoring

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hovercat (0.3.0)
+    hovercat (1.0.0)
       bunny (>= 2.5.1, <= 2.6.0)
       sucker_punch (~> 2.0)
       thor
@@ -109,4 +109,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.0.1
+   1.17.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,4 +109,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.17.2
+   2.0.1

--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@
 </p>
 
 # Hovercat is a client for Rabbitmq 
-Your focuses on ease of use. It focus on 
-to retry send message when message broker is down
+It will retry sending messages when the message broker is down.
 
 ## Supported RabbitMQ Versions
 
@@ -24,32 +23,23 @@ gem 'hovercat', git: 'https://github.com/Mobile4You/hovercat.git'
 
 ### Getting Started
 
-First of all you have to genereate a configuration file
-
-You can generate de configuration file running the following command:
+1 - First of all you have to generate a configuration file, with this command:
 
 ```sh
 $ hovercat memory_store
 ```
 
-It will generate a configuration file like this:
+You could also use redis store:
 
-```rb
-hovercat:
-  rabbitmq:
-    host: 'localhost'
-    port: 5672
-    exchange: ''
-    vhost: '/'
-    user: 'guest'
-    password: 'guest'
-  retries_in_rabbit_mq:
-    retry_attempts: 3
-    retry_delay_in_seconds: 600
+```sh
+$ hovercat redis_store
 ```
-You can specify rabbitmq configurations in configuration file or via params in `Hovercat::Sender.publish`
 
-Creating hovercat message is very simple, you only have to extend `Hovercat::Models::Message`:
+The configuration file will be generated inside the `./config` dir.
+
+You can also send the rabbitmq configurations via params to `Hovercat::Sender.publish`
+
+2 - Creating hovercat message is very simple, you only have to extend `Hovercat::Models::Message`:
 
 Example:
 ```rb
@@ -63,7 +53,7 @@ Example:
   end
 ```
 
-To send a message, you have to use `Hovercat::Sender.publish`:
+3 - To send a message, you have to use `Hovercat::Sender.publish`:
 
 Example:
 ```rb
@@ -71,8 +61,9 @@ Example:
   params = { message: message, exchange: 'my-exchange', header: { 'header-example': 'my-header'} }
   Hovercat::Sender.publish(params)
 ```
-If you use exchange via param, it has precedence over exchange name in configuration file
-### If you have old version of hovervat and would like to upgrade
+If you use exchange via param, it has precedence over exchange name in configuration file.
+
+### If you have an old version of hovercat and would like to upgrade:
 
 1 - Execute
 ```sh
@@ -92,6 +83,8 @@ Hovercat::Models::Message
 Hovercat::Gateways::MessageGateway
 Hovercat::Errors::UnableToSendMessageError
 ```
+
+3 - You may also need to re-generate the configuration file, since the configuration is now defined per environment (development, test, production, etc).
 
 ## Contributing
 

--- a/config/hovercat_memory_storage.yml
+++ b/config/hovercat_memory_storage.yml
@@ -1,11 +1,37 @@
-hovercat:
-  rabbitmq:
-    host: 'localhost'
-    port: 5672
-    exchange: ''
-    vhost: '/'
-    user: 'guest'
-    password: 'guest'
-  retries_in_rabbit_mq:
-    retry_attempts: 3
-    retry_delay_in_seconds: 600
+rabbitmq: &rabbitmq_defaults
+  host: <%= ENV['AMQP_HOST'] || ['localhost'] %>
+  port: <%= ENV['AMQP_PORT'] || 5672 %>
+  exchange: <%= ENV['AMQP_EXCHANGE'] || '' %>
+  vhost: <%= ENV['AMQP_VHOST'] || '/' %>
+  user: <%= ENV['AMQP_USER'] || 'guest' %>
+  password: <%= ENV['AMQP_PWD'] || 'guest' %>
+  log_level: 2
+  log_filename: rabbitmq.log
+  log_age: daily
+
+retries_in_rabbit_mq: &retries_defaults
+  retry_attempts: 3
+  retry_delay_in_seconds: 600
+
+development:
+  hovercat:
+    rabbitmq:
+      <<: *rabbitmq_defaults
+      host: ['localhost']
+    retries_in_rabbit_mq:
+      <<: *retries_defaults
+
+test:
+  hovercat:
+    rabbitmq:
+      <<: *rabbitmq_defaults
+      host: ['localhost']
+    retries_in_rabbit_mq:
+      <<: *retries_defaults
+
+production:
+  hovercat:
+    rabbitmq:
+      <<: *rabbitmq_defaults
+    retries_in_rabbit_mq:
+      <<: *retries_defaults

--- a/lib/hovercat/constants.rb
+++ b/lib/hovercat/constants.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-class Constants
-  REDIS_CONFIGURATION_FILE = "#{Dir.pwd}/config/hovercat_redis_storage.yml"
-  MEMORY_CONFIGURATION_FILE = "#{Dir.pwd}/config/hovercat_memory_storage.yml"
+module Hovercat
+  class Constants
+    REDIS_CONFIGURATION_FILE = "#{Dir.pwd}/config/hovercat_redis_storage.yml"
+    MEMORY_CONFIGURATION_FILE = "#{Dir.pwd}/config/hovercat_memory_storage.yml"
+  end
 end

--- a/lib/hovercat/generators/templates/hovercat_memory_storage.yml.erb
+++ b/lib/hovercat/generators/templates/hovercat_memory_storage.yml.erb
@@ -1,11 +1,37 @@
-hovercat:
-  rabbitmq:
-    host: 'localhost'
-    port: 5672
-    exchange: ''
-    vhost: '/'
-    user: 'guest'
-    password: 'guest'
-  retries_in_rabbit_mq:
-    retry_attempts: 3
-    retry_delay_in_seconds: 600
+rabbitmq: &rabbitmq_defaults
+  host: <%= ENV['AMQP_HOST'] || ['localhost'] %>
+  port: <%= ENV['AMQP_PORT'] || 5672 %>
+  exchange: <%= ENV['AMQP_EXCHANGE'] || '' %>
+  vhost: <%= ENV['AMQP_VHOST'] || '/' %>
+  user: <%= ENV['AMQP_USER'] || 'guest' %>
+  password: <%= ENV['AMQP_PWD'] || 'guest' %>
+  log_level: 2
+  log_filename: rabbitmq.log
+  log_age: daily
+
+retries_in_rabbit_mq: &retries_defaults
+  retry_attempts: 3
+  retry_delay_in_seconds: 600
+
+development:
+  hovercat:
+    rabbitmq:
+      <<: *rabbitmq_defaults
+      host: ['localhost']
+    retries_in_rabbit_mq:
+      <<: *retries_defaults
+
+test:
+  hovercat:
+    rabbitmq:
+      <<: *rabbitmq_defaults
+      host: ['localhost']
+    retries_in_rabbit_mq:
+      <<: *retries_defaults
+
+production:
+  hovercat:
+    rabbitmq:
+      <<: *rabbitmq_defaults
+    retries_in_rabbit_mq:
+      <<: *retries_defaults

--- a/lib/hovercat/generators/templates/hovercat_redis_storage.yml.erb
+++ b/lib/hovercat/generators/templates/hovercat_redis_storage.yml.erb
@@ -1,15 +1,48 @@
-hovercat:
-  rabbitmq:
-    host: 'localhost'
-    port: 5672
-    exchange: ''
-    vhost: '/'
-    user: 'guest'
-    password: 'guest'
-  redis:
-    host: 'localhost'
-    port: 6379
-    db: 'hovercat'
-  retries_in_rabbit_mq:
-    retry_attempts: 3,
-    retry_delay_in_seconds: 600
+rabbitmq: &rabbitmq_defaults
+  host: <%= ENV['AMQP_HOST'] || ['localhost'] %>
+  port: <%= ENV['AMQP_PORT'] || 5672 %>
+  exchange: <%= ENV['AMQP_EXCHANGE'] || '' %>
+  vhost: <%= ENV['AMQP_VHOST'] || '/' %>
+  user: <%= ENV['AMQP_USER'] || 'guest' %>
+  password: <%= ENV['AMQP_PWD'] || 'guest' %>
+  log_level: 2
+  log_filename: rabbitmq.log
+  log_age: daily
+
+retries_in_rabbit_mq: &retries_defaults
+  retry_attempts: 3
+  retry_delay_in_seconds: 600
+
+redis: &redis
+  host: 'localhost'
+  port: 6379
+  db: 'hovercat'
+
+development:
+  hovercat:
+    rabbitmq:
+      <<: *rabbitmq_defaults
+      host: ['localhost']
+    retries_in_rabbit_mq:
+      <<: *retries_defaults
+    redis:
+      <<: *redis
+
+test:
+  hovercat:
+    rabbitmq:
+      <<: *rabbitmq_defaults
+      host: ['localhost']
+    retries_in_rabbit_mq:
+      <<: *retries_defaults
+    redis:
+      <<: *redis
+
+production:
+  hovercat:
+    rabbitmq:
+      <<: *rabbitmq_defaults
+    retries_in_rabbit_mq:
+      <<: *retries_defaults
+    redis:
+      <<: *redis

--- a/lib/hovercat/helpers/configuration.rb
+++ b/lib/hovercat/helpers/configuration.rb
@@ -17,10 +17,16 @@ module Hovercat
       private
 
       def load_config
-        if File.exist?(Constants::REDIS_CONFIGURATION_FILE)
-          YAML.load(ERB.new(File.read(Constants::REDIS_CONFIGURATION_FILE)).result)[environment]
-        elsif File.exist?(Constants::MEMORY_CONFIGURATION_FILE)
-          YAML.load(ERB.new(File.read(Constants::MEMORY_CONFIGURATION_FILE)).result)[environment]
+        memory_file_path = Hovercat::Constants::MEMORY_CONFIGURATION_FILE
+        redis_file_path = Hovercat::Constants::REDIS_CONFIGURATION_FILE
+        whitelist_classes = []
+        whitelist_symbols = []
+        aliases = true
+
+        if File.exist?(redis_file_path)
+          YAML.safe_load(ERB.new(File.read(redis_file_path)).result, whitelist_classes, whitelist_symbols, aliases)[environment]
+        elsif File.exist?(memory_file_path)
+          YAML.safe_load(ERB.new(File.read(memory_file_path)).result, whitelist_classes, whitelist_symbols, aliases)[environment]
         end
       end
 

--- a/lib/hovercat/version.rb
+++ b/lib/hovercat/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Hovercat
-  VERSION = '0.3.0'
+  VERSION = '1.0.0'
 end


### PR DESCRIPTION
Hi, I would like to send these code refactoring:

* Add support to ERB expressions and multiple environments config.

  This change allow to use expressions like `<%= ENV['AMQP_HOST'] || ['localhost'] %>` inside the config file.

  It also separate the config by environment (like development, test, production).


* Scope `Constants` class inside the `Hovercat` module, now it is accessible via `Hovercat::Constants`.

  This change is necessary because the `Constants` class would conflict with a class with the same name, on apps that use this gem.